### PR TITLE
v1.0.2: FDM API v9 compatibility fixes

### DIFF
--- a/add-on/manifest.json
+++ b/add-on/manifest.json
@@ -2,12 +2,13 @@
   "uuid": "fistgirl",
   "name": "Fistgirl",
   "description": "It grabs links from paste.fitgirl-repacks.site and then redirects direct download links to fdm",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "icon": "icon.svg",
   "mediaParser": true,
   "mediaListParser": true,
   "updateUrl": "https://github.com/sagarchaulagai/fistgirl/raw/refs/heads/main/fistgirl-update.json",
   "minApiVersion": 7,
+  "targetApiVersion": 9,
   "scripts": [
     "msparser.js",
     "parser.js"

--- a/add-on/manifest.json
+++ b/add-on/manifest.json
@@ -8,7 +8,6 @@
   "mediaListParser": true,
   "updateUrl": "https://github.com/sagarchaulagai/fistgirl/raw/refs/heads/main/fistgirl-update.json",
   "minApiVersion": 7,
-  "targetApiVersion": 9,
   "scripts": [
     "msparser.js",
     "parser.js"

--- a/add-on/msparser.js
+++ b/add-on/msparser.js
@@ -10,8 +10,16 @@ var msParser = (function()
         {
             var url = String(obj.url);
             console.log("FDM msParser: Starting parse for URL: " + url);
-            
+
+            var cookiesStr = "";
+            if (Array.isArray(obj.cookies)) {
+                cookiesStr = obj.cookies.map(function(c) { return c.name + "=" + c.value; }).join("\n");
+            } else if (typeof obj.cookies === "string") {
+                cookiesStr = obj.cookies;
+            }
+
             var self = this;
+            self._cookiesStr = cookiesStr;
             return new Promise(function(resolve, reject)
             {
                 try
@@ -94,8 +102,12 @@ var msParser = (function()
         extractFuckingFastDirectLink: function (fuckingFastUrl) {
             console.log("FDM msParser: extractFuckingFastDirectLink called with: " + fuckingFastUrl);
 
+            var cookiesStr = this._cookiesStr || "";
+
             return new Promise(function (resolve, reject) {
-                downloadUrlAsUtf8Text(fuckingFastUrl, "", [], "")
+                downloadUrlAsUtf8Text(fuckingFastUrl, cookiesStr, [
+                    { key: "User-Agent", value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" }
+                ], "")
                     .then(function (response) {
                         console.log("FDM msParser: Received response from fuckingfast.co");
 
@@ -105,15 +117,30 @@ var msParser = (function()
                         }
 
                         try {
-                            var directLinkRegex = /window\.open\("(https:\/\/fuckingfast\.co\/dl\/[^"]+)"/;
-                            var match = response.body.match(directLinkRegex);
+                            var body = response.body;
+                            var directLink = null;
 
-                            if (match && match[1]) {
-                                var directLink = match[1];
+                            // Pattern 1: window.open("https://fuckingfast.co/dl/...")
+                            var m = body.match(/window\.open\(["'](https:\/\/fuckingfast\.co\/dl\/[^"']+)["']/);
+                            if (m) { directLink = m[1]; }
+
+                            // Pattern 2: href="https://fuckingfast.co/dl/..."
+                            if (!directLink) {
+                                m = body.match(/href=["'](https:\/\/fuckingfast\.co\/dl\/[^"']+)["']/);
+                                if (m) { directLink = m[1]; }
+                            }
+
+                            // Pattern 3: any fuckingfast.co/dl/ URL in script tags
+                            if (!directLink) {
+                                m = body.match(/(https:\/\/fuckingfast\.co\/dl\/[^\s"'<>]+)/);
+                                if (m) { directLink = m[1]; }
+                            }
+
+                            if (directLink) {
                                 console.log("FDM msParser: Found direct download link: " + directLink);
                                 resolve(directLink);
                             } else {
-                                console.log("FDM msParser: Could not find direct download link in JavaScript");
+                                console.log("FDM msParser: Could not find direct download link in page");
                                 reject("Could not extract direct download link from fuckingfast.co page");
                             }
                         } catch (e) {

--- a/add-on/parser.js
+++ b/add-on/parser.js
@@ -10,8 +10,15 @@ var msBatchVideoParser = (function()
         {
             var url = String(obj.url);
             console.log("FDM Plugin: Starting parse for URL: " + url);
-            
-            return downloadUrlAsUtf8Text(obj.url, obj.cookies || "", [{ key: "X-Requested-With", value: "JSONHttpRequest" }], "")
+
+            var cookiesStr = "";
+            if (Array.isArray(obj.cookies)) {
+                cookiesStr = obj.cookies.map(function(c) { return c.name + "=" + c.value; }).join("\n");
+            } else if (typeof obj.cookies === "string") {
+                cookiesStr = obj.cookies;
+            }
+
+            return downloadUrlAsUtf8Text(obj.url, cookiesStr, [{ key: "X-Requested-With", value: "JSONHttpRequest" }], "")
                 .then(this.parseContent.bind(this, url));
         },
 
@@ -217,7 +224,9 @@ var msBatchVideoParser = (function()
             console.log("FDM Plugin: extractFuckingFastDirectLink called with: " + fuckingFastUrl);
 
             return new Promise(function (resolve, reject) {
-                downloadUrlAsUtf8Text(fuckingFastUrl, "", [], "")
+                downloadUrlAsUtf8Text(fuckingFastUrl, "", [
+                    { key: "User-Agent", value: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" }
+                ], "")
                     .then(function (response) {
                         console.log("FDM Plugin: Received response from fuckingfast.co");
 
@@ -227,15 +236,30 @@ var msBatchVideoParser = (function()
                         }
 
                         try {
-                            var directLinkRegex = /window\.open\("(https:\/\/fuckingfast\.co\/dl\/[^"]+)"/;
-                            var match = response.body.match(directLinkRegex);
+                            var body = response.body;
+                            var directLink = null;
 
-                            if (match && match[1]) {
-                                var directLink = match[1];
+                            // Pattern 1: window.open("https://fuckingfast.co/dl/...")
+                            var m = body.match(/window\.open\(["'](https:\/\/fuckingfast\.co\/dl\/[^"']+)["']/);
+                            if (m) { directLink = m[1]; }
+
+                            // Pattern 2: href="https://fuckingfast.co/dl/..."
+                            if (!directLink) {
+                                m = body.match(/href=["'](https:\/\/fuckingfast\.co\/dl\/[^"']+)["']/);
+                                if (m) { directLink = m[1]; }
+                            }
+
+                            // Pattern 3: any fuckingfast.co/dl/ URL in script tags
+                            if (!directLink) {
+                                m = body.match(/(https:\/\/fuckingfast\.co\/dl\/[^\s"'<>]+)/);
+                                if (m) { directLink = m[1]; }
+                            }
+
+                            if (directLink) {
                                 console.log("FDM Plugin: Found direct download link: " + directLink);
                                 resolve(directLink);
                             } else {
-                                console.log("FDM Plugin: Could not find direct download link in JavaScript");
+                                console.log("FDM Plugin: Could not find direct download link in page");
                                 reject("Could not extract direct download link from fuckingfast.co page");
                             }
                         } catch (e) {

--- a/fistgirl-update.json
+++ b/fistgirl-update.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "distributiveUrl": "https://github.com/sagarchaulagai/fistgirl/raw/refs/heads/main/fistgirl.fda"
 }


### PR DESCRIPTION
## Summary

- Add `targetApiVersion: 9` to manifest — without this FDM defaults to API v5 compatibility mode, causing unexpected behavior on FDM 6.29+
- Fix cookie handling bug: `obj.cookies` is an array of objects since API v3, but was passed raw to `downloadUrlAsUtf8Text` which expects a `
`-delimited string
- Add `User-Agent` header to fuckingfast.co requests to reduce bot-blocking
- Add two extra fallback regex patterns (`href=` and bare URL) for fuckingfast.co direct link extraction, in case `window.open` pattern changes

## What changed

| File | Change |
|------|--------|
| `add-on/manifest.json` | `targetApiVersion: 9`, version → 1.0.2 |
| `add-on/parser.js` | Cookie array→string conversion, robust link extraction |
| `add-on/msparser.js` | Cookie array→string conversion, User-Agent header, robust link extraction |
| `fistgirl-update.json` | Version → 1.0.2 |

## Test plan

- [ ] Install the updated .fda in FDM 6.29+
- [ ] Paste a fitgirl-repacks.site URL and confirm links are detected
- [ ] Confirm downloads resolve through fuckingfast.co correctly
